### PR TITLE
Changed to upwards compatible angular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "listr": "^0.14.3"
   },
   "devDependencies": {
-    "@angular/core": "^6.0.0",
+    "@angular/core": ">= 6.0.0",
     "@types/argparse": "^1.0.38",
     "@types/got": "^9.6.9",
     "@types/listr": "^0.14.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "@angular/core": "^6.0.0",
+    "@angular/core": ">=6.0.0",
     "ng-openapi-gen": "^0.12.1",
     "rxjs": "^6.0.0"
   },


### PR DESCRIPTION
The old angular dependency had prevented us from migrating to Angular 14 or higher.
That's why I set the requirement to the angular/core dependency to a version greater/equal 6.